### PR TITLE
feat: allow building specific versions of ldid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 
 FROM alpine
 
+ARG ref=master
+
 RUN apk add --no-cache \
     build-base \
     git \
@@ -13,7 +15,7 @@ RUN apk add --no-cache \
 
 WORKDIR /root
 
-RUN git clone git://git.saurik.com/ldid.git
+RUN git clone --depth 1 --branch $ref git://git.saurik.com/ldid.git
 
 WORKDIR /root/ldid
 


### PR DESCRIPTION
For example: `docker build --build-arg ref=v2.1.5` to build v2.1.5 of ldid.